### PR TITLE
Solve issue #4, install missed package for ubuntu 22

### DIFF
--- a/pc2cluster.yml
+++ b/pc2cluster.yml
@@ -27,17 +27,17 @@
   collections:
           - community.general
   become: yes
-  gather_facts: no
+  gather_facts: yes
   roles:
-          - roles/init-env
-          - roles/initdisk
-          - roles/config_drbd
-          - roles/config_cluster
-          - roles/config_ipres
-          - roles/config_pc2res
-          - roles/config_drbdres
-          - roles/config_fsmountres
-          - roles/finalize
+   - roles/init-env
+   - roles/initdisk
+   - roles/config_drbd
+   - roles/config_cluster
+   - roles/config_ipres
+   - roles/config_pc2res
+   - roles/config_drbdres
+   - roles/config_fsmountres
+   - roles/finalize
             #- roles/init_env
             #- roles/initial
             #- roles/kube-dependencies

--- a/roles/init-env/tasks/main.yml
+++ b/roles/init-env/tasks/main.yml
@@ -19,6 +19,14 @@
            - wget
           state: present
 
+##Task executed only for ubuntu >= 22
+- name: Install resource agents package 
+  ansible.builtin.package:
+          name:
+                  - resource-agents
+          state: present
+  when: "{{ ansible_distribution_major_version }} >= 22"
+
 - name: Create mount point
   ansible.builtin.file:
           path: /pc2data
@@ -38,6 +46,6 @@
 
 - name: Create a softlink to PC2 installation directory
   ansible.builtin.file:
-          src: /usr/local/pc2-9.8build
+          src: /usr/local/pc2-9.9build
           dest: /usr/local/pc2
           state: link


### PR DESCRIPTION
1-Adding a task called "Install resource agents package" in the role "init-env" to install the package if and only if the major distribution is >= 22
2-Modify pc2cluster.yml to gather_facts by settings gather_facts: yes in the playbook