### PR TITLE
Resolving issue #6, error runnign disable stonith task

### DIFF
--- a/roles/config_cluster/tasks/main.yml
+++ b/roles/config_cluster/tasks/main.yml
@@ -50,8 +50,14 @@
   notify:
           - Restart pacemaker
 
+- name: Restart pacemaker task
+  ansible.builtin.service:
+          name: pacemaker
+          state: restarted
+
 - name: Disable stonith
-  shell: pcs property set stonith-enabled=FALSE && touch disable-stonith.txt
+  become: true
+  shell: pcs property set stonith-enabled=false && touch disable-stonith.txt
   args:
           creates: disable-stonith.txt
   when: inventory_hostname in groups['clusteradmin']


### PR DESCRIPTION
The problem because the cluster was not restarted. in the preseeding task "Create the cluster", it fires the handler that start pacemaker, but the handler executed at the end of playbook. We need to add task that restarts the pacemaker explicitly. so that added the task "Restart pacemaker task" to start the cluster.