### PR TITLE
Issue: 22: config_cluster-delay-is-not-sufficeient

### DIFF
--- a/roles/config_cluster/tasks/main.yml
+++ b/roles/config_cluster/tasks/main.yml
@@ -77,4 +77,4 @@
 
 - name: Sleep for a while
   ansible.builtin.pause:
-    seconds: 30
+    seconds: 60


### PR DESCRIPTION
Updated and increased the pause period to be 60 seconds