### PR TITLE
Issue: 24: wrong-fs-mount-during-resource-configuration

### DIFF
--- a/pc2cluster.yml
+++ b/pc2cluster.yml
@@ -29,21 +29,13 @@
   become: yes
   gather_facts: yes
   roles:
-   - roles/init-env
-   - roles/initdisk
-   - roles/config_drbd
-   - roles/config_cluster
-   - roles/config_ipres
-   - roles/config_pc2res
-   - roles/config_drbdres
-   - roles/config_fsmountres
-   - roles/finalize
-            #- roles/init_env
-            #- roles/initial
-            #- roles/kube-dependencies
-            #- role: roles/kube-dependencies-adm
-            #when: inventory_hostname in groups['clusteradmin']
-            #- role: roles/configmaster
-            #when: inventory_hostname in groups['clusteradmin']
-            #- role: roles/configworker
+    - roles/init-env
+    - roles/initdisk
+    - roles/config_drbd
+    - roles/config_cluster
+    - roles/config_ipres
+    - roles/config_drbdres
+    - roles/config_fsmountres
+    - roles/config_pc2res
+    - roles/finalize
 


### PR DESCRIPTION
Order or executing role roles/config_pc2res to be after roles/config_fsmountres